### PR TITLE
Bug Fix in 'drvUserCreate', Fix record missing alarms status update, Fix record type for LogLevel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@
 /iocBoot/*ioc*/dllPath.bat
 /iocBoot/*ioc*/envPaths
 /iocBoot/*ioc*/relPaths.sh
-
+/iocBoot/*ioc*/*.cmd
 # Build directories
 O.*/
 

--- a/drvAsynIseghalServiceApp/Db/can-items.template
+++ b/drvAsynIseghalServiceApp/Db/can-items.template
@@ -44,7 +44,7 @@ record( stringin, "$(P)$(R):CAN$(ID=0)-CrateList") {
     field(TSE,  "-2")
 }
 
-record(longout, "$(P)$(R):CAN$(ID=0)-LogLevel") {
+record(mbbo, "$(P)$(R):CAN$(ID=0)-LogLevel") {
     field(DTYP, "asynInt32")
     field(OUT,  "@asyn($(PORT))INT_LogLevel($(CANLINE=0))")
     field(ZRVL, "1")

--- a/drvAsynIseghalServiceApp/Db/can-items.template
+++ b/drvAsynIseghalServiceApp/Db/can-items.template
@@ -1,7 +1,7 @@
 ###############################
 # CAN Line items
 ###############################
-record( longin, "$(P)$(R):CAN$(ID=0)-Status") {
+record( mbbiDirect, "$(P)$(R):CAN$(ID=0)-Status") {
     field(DESC, "CAN Line status")
     field(DTYP, "asynUInt32Digital")
     field(INP,  "@asynMask($(PORT),0, 0xf)DIG_Status($(CANLINE=0))")
@@ -44,9 +44,9 @@ record( stringin, "$(P)$(R):CAN$(ID=0)-CrateList") {
     field(TSE,  "-2")
 }
 
-record(mbbo, "$(P)$(R):CAN$(ID=0)-LogLevel") {
-    field(DTYP, "asynUInt32Digital")
-    field(OUT,  "@asynMask($(PORT),0, 0xf)DIG_LogLevel($(CANLINE=0))")
+record(longout, "$(P)$(R):CAN$(ID=0)-LogLevel") {
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT))INT_LogLevel($(CANLINE=0))")
     field(ZRVL, "1")
     field(ZRST, "Log Errors")
     field(ONVL, "2")
@@ -75,5 +75,80 @@ record(mbbo, "$(P)$(R):CAN$(ID=0)-LogLevel") {
     field(TTST, "Log Scpi Write Request")
 
     info(asyn:READBACK, "1")
-    info(DESCRIPTION, "Set RF Control Ouput Sel, on I and Q")
+    info(DESCRIPTION, "Set Log Level on this CAN line")
+}
+
+#####################################
+# ### Decoding of CAN Line Status ### #
+#####################################
+record( bi, "$(P)$(R):CAN$(ID=0)-ErrorActive" ) {
+    field(DESC, "CAN State Error Active")
+    field(INP,  "$(P)$(R):CAN$(ID=0)-Status.B0 CP" )
+    field(ZNAM, "off" )
+    field(ONAM, "on" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CAN$(ID=0)-ErrorWarning" ) {
+    field(INP,  "$(P)$(R):CAN$(ID=0)-Status.B1 CP" )
+    field(DESC, "CAN State Error Warning")
+    field(ZNAM, "off" )
+    field(ONAM, "on" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "NO_ALARM" )
+}
+
+record( bi, "$(P)$(R):CAN$(ID=0)-ErrorPassive" ) {
+    field(INP,  "$(P)$(R):CAN$(ID=0)-Status.B2 CP" )
+    field(DESC, "CAN State Error Passive")
+    field(ZNAM, "off" )
+    field(ONAM, "on" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "NO_ALARM" )
+}
+
+record( bi, "$(P)$(R):CAN$(ID=0)-BusOff" ) {
+    field(INP,  "$(P)$(R):CAN$(ID=0)-Status.B3 CP" )
+    field(DESC, "CAN State Bus Off")
+    field(ZNAM, "ok" )
+    field(ONAM, "Bus Off" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CAN$(ID=0)-Stopped" ) {
+    field(INP,  "$(P)$(R):CAN$(ID=0)-Status.B4 CP " )
+    field(DESC, "CAN State Stopped")
+    field(ZNAM, "ok" )
+    field(ONAM, "Error" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CAN$(ID=0)-Sleeping" ) {
+    field(INP,  "$(P)$(R):CAN$(ID=0)-Status.B5 CP " )
+    field(DESC, "CAN State Sleeping")
+    field(ZNAM, "ok" )
+    field(ONAM, "Error" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MINOR" )
+}
+
+record( bi, "$(P)$(R):CAN$(ID=0)-SeriouslyError" ) {
+    field(INP,  "$(P)$(R):CAN$(ID=0)-Status.B6 CP " )
+    field(DESC, "CAN State Seriously Error")
+    field(ZNAM, "ok" )
+    field(ONAM, "Error" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CAN$(ID=0)-Undefined" ) {
+    field(INP,  "$(P)$(R):CAN$(ID=0)-Status.B7 CP " )
+    field(DESC, "CAN State Undefined")
+    field(ZNAM, "ok" )
+    field(ONAM, "Error" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MINOR" )
 }

--- a/drvAsynIseghalServiceApp/Db/crate-items.template
+++ b/drvAsynIseghalServiceApp/Db/crate-items.template
@@ -4,25 +4,7 @@
 record( longin, "$(P)$(R):CRATE$(ID=1000)-Status") {
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT))INT_Status($(LINEADDR=0.1000))")
-    field(FLNK, "$(P)$(R):CRATE$(ID=1000)-StatusHigh")
     field(SCAN, "I/O Intr")
-    field(TSE,  "-2")
-}
-
-record( mbbiDirect, "$(P)$(R):CRATE$(ID=1000)-StatusHigh") {
-    field(DESC, "Upper 16 bit of module status register")
-    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status")
-    field(NOBT, "16")
-    field(SHFT, "16")
-    field(TSE,  "-2")
-    field(FLNK, "$(P)$(R):CRATE$(ID=1000)-StatusLow")
-}
-
-record( mbbiDirect, "$(P)$(R):CRATE$(ID=1000)-StatusLow") {
-    field(DESC, "Lower 16 bit of module status register")
-    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status")
-    field(NOBT, "16")
-    field(SHFT, "0")
     field(TSE,  "-2")
 }
 
@@ -139,4 +121,148 @@ record( stringin, "$(P)$(R):CRATE$(ID=1000)-Article") {
     field(DTYP, "asynOctetRead")
     field(INP,  "@asyn($(PORT))STR_Article($(LINEADDR=0.1000))")
     field(TSE,  "-2" )
+}
+
+# todo:
+# Status:11 - high +3.3 crate controller
+# Status:10 - low +3.3 crate controller
+# Status:9 - high +5 crate controller
+# Status:8 - low +5 crate controller
+
+#####################################
+# ### Decoding of Crate Status ### #
+#####################################
+record( bi, "$(P)$(R):CRATE$(ID=1000)-Low24VBat" ) {
+    field(DESC, "low +24 battery")
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.B0 CP" )
+    field(ZNAM, "ok" )
+    field(ONAM, "low +24 battery" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-High24VBat" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.B1 CP" )
+    field(DESC, "high +24 battery")
+    field(ZNAM, "ok" )
+    field(ONAM, "high +24 battery" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-Low5VBp" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.B2 CP" )
+    field(DESC, "low +5 backplane")
+    field(ZNAM, "off" )
+    field(ONAM, "on" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "NO_ALARM" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-High5VBp" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.B3 CP" )
+    field(DESC, "high +5 backplane")
+    field(ZNAM, "ok" )
+    field(ONAM, "high +5 backplane" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-Low24VBp" ) {
+    field(DESC, "low +24 backplane")
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.B4 CP" )
+    field(ZNAM, "ok" )
+    field(ONAM, "low +24 backplane" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-High24VBp" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.B5 CP" )
+    field(DESC, "high +24 backplane")
+    field(ZNAM, "ok" )
+    field(ONAM, "high +24 backplane" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-needService" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.B6 CP " )
+    field(DESC, "service")
+    field(ZNAM, "ok" )
+    field(ONAM, "service" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-Temperature" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.B7 CP " )
+    field(DESC, "high temperature")
+    field(ZNAM, "ok" )
+    field(ONAM, "high temperature" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-SumError" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.BC CP " )
+    field(DESC, "sum error" )
+    field(ZNAM, "ok" )
+    field(ONAM, "sum error" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-PowerOn" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.BD CP " )
+    field(DESC, "power on" )
+    field(ZNAM, "power off" )
+    field(ONAM, "power on" )
+    field(ZSV,  "MAJOR" )
+    field(OSV,  "NO_ALARM" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-PowerFail" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.BE CP " )
+    field(DESC, "Crate Power fail status" )
+    field(ZNAM, "ok" )
+    field(ONAM, "power fail" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-HVOn" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.BF CP " )
+    field(DESC, "high voltage on" )
+    field(ZNAM, "HV Off" )
+    field(ONAM, "HV On" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "NO_ALARM" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-ShutDown" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.BG CP " )
+    field(DESC, "Crate shut down" )
+    field(ZNAM, "alive" )
+    field(ONAM, "shut down" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-Enabled" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.BH CP " )
+    field(DESC, "Crate enabled" )
+    field(ZNAM, "Disbaled" )
+    field(ONAM, "Enabled" )
+    field(ZSV,  "MINOR" )
+    field(OSV,  "NO_ALARM" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-FastOff" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.BI CP" )
+    field(DESC, "Crate fast off" )
+    field(ZNAM, "Off" )
+    field(ONAM, "On" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "NO_ALARM" )
 }

--- a/drvAsynIseghalServiceApp/Db/drvAsynIseghalService.db
+++ b/drvAsynIseghalServiceApp/Db/drvAsynIseghalService.db
@@ -4,8 +4,8 @@
 
 record( longin, "$(P)$(R):SYS-Status") {
     field(DESC, "CAN system Status")
-    field(DTYP, "asynUInt32Digital")
-    field(INP,  "@asynMask($(PORT),0, 0xf)DIG_Status")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT))INT_Status")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
 }
@@ -90,9 +90,9 @@ record( stringin, "$(P)$(R):SYS-LogPath-RB") {
     field(TSE,  "-2")
 }
 
-record(mbbo, "$(P)$(R):SYS-LogLevel") {
-    field(DTYP, "asynUInt32Digital")
-    field(OUT,  "@asynMask($(PORT),0, 0xf)DIG_LogLevel")
+record(longout, "$(P)$(R):SYS-LogLevel") {
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT))INT_LogLevel")
     field(ZRVL, "1")
     field(ZRST, "Log Errors")
     field(ONVL, "2")
@@ -121,12 +121,12 @@ record(mbbo, "$(P)$(R):SYS-LogLevel") {
     field(TTST, "Log Scpi Write Request")
 
     info(asyn:READBACK, "1")
-    info(DESCRIPTION, "Set RF Control Ouput Sel, on I and Q")
+    info(DESCRIPTION, "Set Log Level at system level")
 }
 ###############################
 # CAN Line items
 ###############################
-record( longin, "$(P)$(R):CAN$(ID=0)-Status") {
+record( mbbiDirect, "$(P)$(R):CAN$(ID=0)-Status") {
     field(DESC, "CAN Line status")
     field(DTYP, "asynUInt32Digital")
     field(INP,  "@asynMask($(PORT),0, 0xf)DIG_Status($(CANLINE=0))")
@@ -169,9 +169,9 @@ record( stringin, "$(P)$(R):CAN$(ID=0)-CrateList") {
     field(TSE,  "-2")
 }
 
-record(mbbo, "$(P)$(R):CAN$(ID=0)-LogLevel") {
-    field(DTYP, "asynUInt32Digital")
-    field(OUT,  "@asynMask($(PORT),0, 0xf)DIG_LogLevel($(CANLINE=0))")
+record(longout, "$(P)$(R):CAN$(ID=0)-LogLevel") {
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT))INT_LogLevel($(CANLINE=0))")
     field(ZRVL, "1")
     field(ZRST, "Log Errors")
     field(ONVL, "2")
@@ -200,9 +200,351 @@ record(mbbo, "$(P)$(R):CAN$(ID=0)-LogLevel") {
     field(TTST, "Log Scpi Write Request")
 
     info(asyn:READBACK, "1")
-    info(DESCRIPTION, "Set RF Control Ouput Sel, on I and Q")
+    info(DESCRIPTION, "Set Log Level on this CAN line")
 }
 
+#####################################
+# ### Decoding of CAN Line Status ### #
+#####################################
+record( bi, "$(P)$(R):CAN$(ID=0)-ErrorActive" ) {
+    field(DESC, "CAN State Error Active")
+    field(INP,  "$(P)$(R):CAN$(ID=0)-Status.B0 CP" )
+    field(ZNAM, "off" )
+    field(ONAM, "on" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CAN$(ID=0)-ErrorWarning" ) {
+    field(INP,  "$(P)$(R):CAN$(ID=0)-Status.B1 CP" )
+    field(DESC, "CAN State Error Warning")
+    field(ZNAM, "off" )
+    field(ONAM, "on" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "NO_ALARM" )
+}
+
+record( bi, "$(P)$(R):CAN$(ID=0)-ErrorPassive" ) {
+    field(INP,  "$(P)$(R):CAN$(ID=0)-Status.B2 CP" )
+    field(DESC, "CAN State Error Passive")
+    field(ZNAM, "off" )
+    field(ONAM, "on" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "NO_ALARM" )
+}
+
+record( bi, "$(P)$(R):CAN$(ID=0)-BusOff" ) {
+    field(INP,  "$(P)$(R):CAN$(ID=0)-Status.B3 CP" )
+    field(DESC, "CAN State Bus Off")
+    field(ZNAM, "ok" )
+    field(ONAM, "Bus Off" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CAN$(ID=0)-Stopped" ) {
+    field(INP,  "$(P)$(R):CAN$(ID=0)-Status.B4 CP " )
+    field(DESC, "CAN State Stopped")
+    field(ZNAM, "ok" )
+    field(ONAM, "Error" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CAN$(ID=0)-Sleeping" ) {
+    field(INP,  "$(P)$(R):CAN$(ID=0)-Status.B5 CP " )
+    field(DESC, "CAN State Sleeping")
+    field(ZNAM, "ok" )
+    field(ONAM, "Error" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MINOR" )
+}
+
+record( bi, "$(P)$(R):CAN$(ID=0)-SeriouslyError" ) {
+    field(INP,  "$(P)$(R):CAN$(ID=0)-Status.B6 CP " )
+    field(DESC, "CAN State Seriously Error")
+    field(ZNAM, "ok" )
+    field(ONAM, "Error" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CAN$(ID=0)-Undefined" ) {
+    field(INP,  "$(P)$(R):CAN$(ID=0)-Status.B7 CP " )
+    field(DESC, "CAN State Undefined")
+    field(ZNAM, "ok" )
+    field(ONAM, "Error" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MINOR" )
+}
+#######################################################
+# ### Crate items: CC24/CC23/CC44/CC43 only ### #
+#######################################################
+record( longin, "$(P)$(R):CRATE$(ID=1000)-Status") {
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT))INT_Status($(LINEADDR=0.1000))")
+    field(SCAN, "I/O Intr")
+    field(TSE,  "-2")
+}
+
+record( longin, "$(P)$(R):CRATE$(ID=1000)-EventStatus") {
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT))INT_EventStatus($(LINEADDR=0.1000))")
+    field(FLNK, "$(P)$(R):CRATE$(ID=1000)-EventStatusHigh")
+    field(SCAN, "I/O Intr")
+}
+
+record( mbbiDirect, "$(P)$(R):CRATE$(ID=1000)-EventStatusHigh") {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-EventStatus")
+    field(NOBT, "16")
+    field(SHFT, "16")
+    field(TSE,  "-2")
+    field(FLNK, "$(P)$(R):CRATE$(ID=1000)-EventStatusLow")
+}
+
+record( mbbiDirect, "$(P)$(R):CRATE$(ID=1000)-EventStatusLow") {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-EventStatus")
+    field(NOBT, "16")
+    field(SHFT, "0")
+    field(TSE,  "-2")
+}
+
+record( longout, "$(P)$(R):CRATE$(ID=1000)-EventMask") {
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT))INT_EventMask($(LINEADDR=0.1000))")
+    field(TSE,  "-2")
+}
+
+record( ai, "$(P)$(R):CRATE$(ID=1000)-FanSpeed") {
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT))DBL_FanSpeed($(LINEADDR=0.1000))")
+    field(TSE,  "-2")
+}
+
+record( bo, "$(P)$(R):CRATE$(ID=1000)-DoClearEvents") {
+    field(DESC, "do clear all events")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT))INT_Control:0($(LINEADDR=0.1000))")
+    field(ZNAM, "")
+    field(ONAM, "Do clear event")
+    field(TSE,  "-2")
+}
+
+record( bo, "$(P)$(R):CRATE$(ID=1000)-SetEnAct") {
+    field(DESC, "set crate enable active")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT))INT_Control:24($(LINEADDR=0.1000))")
+    field(ZNAM, "")
+    field(ONAM, "Enable active")
+    field(TSE,  "-2")
+}
+
+record( bo, "$(P)$(R):CRATE$(ID=1000)-DoSetEnAct") {
+    field(DESC, "do set crate enable active")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT))INT_Control:25($(LINEADDR=0.1000))")
+    field(ZNAM, "")
+    field(ONAM, "Enable active")
+    field(TSE,  "-2")
+}
+
+record( bo, "$(P)$(R):CRATE$(ID=1000)-SetHVBkpAuto") {
+    field(DESC, "set HV backplane auto on")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT))INT_Control:26($(LINEADDR=0.1000))")
+    field(ZNAM, "")
+    field(ONAM, "HV bkp auto on")
+    field(TSE,  "-2")
+}
+
+record( bo, "$(P)$(R):CRATE$(ID=1000)-DoSetHVBkpAuto") {
+    field(DESC, "do set HV backplane auto on")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT))INT_Control:27($(LINEADDR=0.1000))")
+    field(ZNAM, "")
+    field(ONAM, "HV bkp auto on")
+    field(TSE,  "-2")
+}
+
+record( longin, "$(P)$(R):CRATE$(ID=1000)-SerialNumber") {
+    field(DESC, "Crate serial number")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT))INT_SerialNumber($(LINEADDR=0.1000))")
+    field(TSE,  "-2")
+}
+
+record( bo, "$(P)$(R):CRATE$(ID=1000)-PowerOn") {
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT))INT_PowerOn($(LINEADDR=0.1000))")
+    field(TSE,  "-2")
+    field(ZNAM, "Off")
+    field(ONAM, "On")
+}
+
+record( stringin, "$(P)$(R):CRATE$(ID=1000)-FirmwareRelease") {
+    field(DESC, "Crate firmware release")
+    field(DTYP, "asynOctetRead")
+    field(INP,  "@asyn($(PORT))STR_FirmwareRelease($(LINEADDR=0.1000))")
+    field(TSE,  "-2" )
+}
+
+record( stringin, "$(P)$(R):CRATE$(ID=1000)-FirmwareName") {
+    field(DESC, "Crate firmware name")
+    field(DTYP, "asynOctetRead")
+    field(INP,  "@asyn($(PORT))STR_FirmwareName($(LINEADDR=0.1000))")
+    field(TSE,  "-2" )
+}
+
+record( stringin, "$(P)$(R):CRATE$(ID=1000)-Article") {
+    field(DESC, "Crate articles")
+    field(DTYP, "asynOctetRead")
+    field(INP,  "@asyn($(PORT))STR_Article($(LINEADDR=0.1000))")
+    field(TSE,  "-2" )
+}
+
+# todo:
+# Status:11 - high +3.3 crate controller
+# Status:10 - low +3.3 crate controller
+# Status:9 - high +5 crate controller
+# Status:8 - low +5 crate controller
+
+#####################################
+# ### Decoding of Crate Status ### #
+#####################################
+record( bi, "$(P)$(R):CRATE$(ID=1000)-Low24VBat" ) {
+    field(DESC, "low +24 battery")
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.B0 CP" )
+    field(ZNAM, "ok" )
+    field(ONAM, "low +24 battery" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-High24VBat" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.B1 CP" )
+    field(DESC, "high +24 battery")
+    field(ZNAM, "ok" )
+    field(ONAM, "high +24 battery" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-Low5VBp" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.B2 CP" )
+    field(DESC, "low +5 backplane")
+    field(ZNAM, "off" )
+    field(ONAM, "on" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "NO_ALARM" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-High5VBp" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.B3 CP" )
+    field(DESC, "high +5 backplane")
+    field(ZNAM, "ok" )
+    field(ONAM, "high +5 backplane" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-Low24VBp" ) {
+    field(DESC, "low +24 backplane")
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.B4 CP" )
+    field(ZNAM, "ok" )
+    field(ONAM, "low +24 backplane" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-High24VBp" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.B5 CP" )
+    field(DESC, "high +24 backplane")
+    field(ZNAM, "ok" )
+    field(ONAM, "high +24 backplane" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-needService" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.B6 CP " )
+    field(DESC, "service")
+    field(ZNAM, "ok" )
+    field(ONAM, "service" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-Temperature" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.B7 CP " )
+    field(DESC, "high temperature")
+    field(ZNAM, "ok" )
+    field(ONAM, "high temperature" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-SumError" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.BC CP " )
+    field(DESC, "sum error" )
+    field(ZNAM, "ok" )
+    field(ONAM, "sum error" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-PowerOn" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.BD CP " )
+    field(DESC, "power on" )
+    field(ZNAM, "power off" )
+    field(ONAM, "power on" )
+    field(ZSV,  "MAJOR" )
+    field(OSV,  "NO_ALARM" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-PowerFail" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.BE CP " )
+    field(DESC, "Crate Power fail status" )
+    field(ZNAM, "ok" )
+    field(ONAM, "power fail" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-HVOn" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.BF CP " )
+    field(DESC, "high voltage on" )
+    field(ZNAM, "HV Off" )
+    field(ONAM, "HV On" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "NO_ALARM" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-ShutDown" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.BG CP " )
+    field(DESC, "Crate shut down" )
+    field(ZNAM, "alive" )
+    field(ONAM, "shut down" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-Enabled" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.BH CP " )
+    field(DESC, "Crate enabled" )
+    field(ZNAM, "Disbaled" )
+    field(ONAM, "Enabled" )
+    field(ZSV,  "MINOR" )
+    field(OSV,  "NO_ALARM" )
+}
+
+record( bi, "$(P)$(R):CRATE$(ID=1000)-FastOff" ) {
+    field(INP,  "$(P)$(R):CRATE$(ID=1000)-Status.BI CP" )
+    field(DESC, "Crate fast off" )
+    field(ZNAM, "Off" )
+    field(ONAM, "On" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "NO_ALARM" )
+}
 ##############################
 # ### Module item values ### #
 ##############################
@@ -553,7 +895,6 @@ record( bi, "$(P)$(R):MOD$(ID=0)-EventTemperatureNotGood" ) {
     field(ZSV,  "NO_ALARM" )
     field(OSV,  "MAJOR" )
 }
-
 ###############################
 # ### Channel item values ### #
 ###############################

--- a/drvAsynIseghalServiceApp/Db/module-items.template
+++ b/drvAsynIseghalServiceApp/Db/module-items.template
@@ -61,6 +61,8 @@ record( bo, "$(P)$(R):MOD$(ID=0)-SetFineAdjustment" ) {
     field(ZNAM, "FineAdjustment off" )
     field(ONAM, "FineAdjustment on" )
     field(TSE,  "-2" )
+
+    info(asyn:READBACK, "1")
 }
 
 record( bo, "$(P)$(R):MOD$(ID=0)-SetKillEnable" ) {
@@ -70,6 +72,8 @@ record( bo, "$(P)$(R):MOD$(ID=0)-SetKillEnable" ) {
     field(ZNAM, "KillEnable off" )
     field(ONAM, "KillEnable on" )
     field(TSE,  "-2" )
+
+    info(asyn:READBACK, "1")
 }
 
 record( bo, "$(P)$(R):MOD$(ID=0)-disVoltageRampSpeedLimit" ) {
@@ -123,6 +127,7 @@ record( ai, "$(P)$(R):MOD$(ID=0)-Temperature" ) {
 
 record( longin, "$(P)$(R):MOD$(ID=0)-SerialNumber" ) {
     field(DESC, "Module Serial number")
+    field(PINI, "RUNNING")
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT))INT_SerialNumber($(LINEADDR=0.0))")
     field(TSE,  "-2" )
@@ -130,6 +135,7 @@ record( longin, "$(P)$(R):MOD$(ID=0)-SerialNumber" ) {
 
 record( longin, "$(P)$(R):MOD$(ID=0)-ChannelNumber" ) {
     field(DESC, "Number of Channel on module")
+    field(PINI, "RUNNING")
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT))INT_ChannelNumber($(LINEADDR=0.0))")
     field(TSE,  "-2" )
@@ -137,6 +143,7 @@ record( longin, "$(P)$(R):MOD$(ID=0)-ChannelNumber" ) {
 
 record( longin, "$(P)$(R):MOD$(ID=0)-SampleRate" ) {
     field(DESC, "Acquisition Sample Rate")
+    field(PINI, "RUNNING")
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT))INT_SampleRate($(LINEADDR=0.0))")
     field(TSE,  "-2" )
@@ -144,6 +151,7 @@ record( longin, "$(P)$(R):MOD$(ID=0)-SampleRate" ) {
 
 record( longin, "$(P)$(R):MOD$(ID=0)-DigitalFilter" ) {
     field(DESC, "MICC Module Digital filter")
+    field(PINI, "RUNNING")
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT))INT_DigitalFilter($(LINEADDR=0.0))")
     field(TSE,  "-2" )
@@ -151,6 +159,7 @@ record( longin, "$(P)$(R):MOD$(ID=0)-DigitalFilter" ) {
 
 record( stringin, "$(P)$(R):MOD$(ID=0)-FirmwareRelease" ) {
     field(DESC, "Module Firmware release")
+    field(PINI, "RUNNING")
     field(DTYP, "asynOctetRead")
     field(INP,  "@asyn($(PORT))STR_FirmwareRelease($(LINEADDR=0.0))")
     field(TSE,  "-2" )
@@ -158,6 +167,7 @@ record( stringin, "$(P)$(R):MOD$(ID=0)-FirmwareRelease" ) {
 
 record( stringin, "$(P)$(R):MOD$(ID=0)-FirmwareName" ) {
     field(DESC, "Module Firmware name")
+    field(PINI, "RUNNING")
     field(DTYP, "asynOctetRead")
     field(INP,  "@asyn($(PORT))STR_FirmwareName($(LINEADDR=0.0))")
     field(TSE,  "-2" )
@@ -165,6 +175,7 @@ record( stringin, "$(P)$(R):MOD$(ID=0)-FirmwareName" ) {
 
 record( stringin, "$(P)$(R):MOD$(ID=0)-Article" ) {
     field(DESC, "Article description")
+    field(PINI, "RUNNING")
     field(DTYP, "asynOctetRead")
     field(INP,  "@asyn($(PORT))STR_Article($(LINEADDR=0.0))")
     field(TSE,  "-2" )
@@ -192,7 +203,7 @@ record( bi, "$(P)$(R):MOD$(ID=0)-FineAdjustment" ) {
 
 record( bi, "$(P)$(R):MOD$(ID=0)-LiveInsertion" ) {
     field(INP,  "$(P)$(R):MOD$(ID=0)-Status.B2 CP" )
-    field(DESC, "Mode live insertion")
+    field(DESC, "Live insertion mode")
     field(ZNAM, "off" )
     field(ONAM, "on" )
     field(ZSV,  "NO_ALARM" )
@@ -229,28 +240,28 @@ record( bi, "$(P)$(R):MOD$(ID=0)-InputError" ) {
 record( bi, "$(P)$(R):MOD$(ID=0)-NoSumError" ) {
     field(INP,  "$(P)$(R):MOD$(ID=0)-Status.B8 CP " )
     field(DESC, "All channle without failure")
-    field(ZNAM, "Error" )
-    field(ONAM, "ok" )
-    field(ZSV,  "MAJOR" )
-    field(OSV,  "NO_ALARM" )
+    field(ZNAM, "ok" )
+    field(ONAM, "Error" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
 }
 
 record( bi, "$(P)$(R):MOD$(ID=0)-NoRamp" ) {
     field(INP,  "$(P)$(R):MOD$(ID=0)-Status.B9 CP " )
     field(DESC, "All channles stable, no ramp active" )
-    field(ZNAM, "channel is ramping" )
-    field(ONAM, "all channels stable" )
+    field(ZNAM, "all channels stable" )
+    field(ONAM, "channel is ramping" )
     field(ZSV,  "NO_ALARM" )
-    field(OSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
 }
 
 record( bi, "$(P)$(R):MOD$(ID=0)-SafetyLoopGood" ) {
     field(INP,  "$(P)$(R):MOD$(ID=0)-Status.BA CP " )
     field(DESC, "Safety loop closed" )
-    field(ZNAM, "broken" )
-    field(ONAM, "closed" )
-    field(ZSV,  "MAJOR" )
-    field(OSV,  "NO_ALARM" )
+    field(ZNAM, "closed" )
+    field(ONAM, "broken" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
 }
 
 record( bi, "$(P)$(R):MOD$(ID=0)-EventActive" ) {
@@ -265,28 +276,28 @@ record( bi, "$(P)$(R):MOD$(ID=0)-EventActive" ) {
 record( bi, "$(P)$(R):MOD$(ID=0)-ModuleGood" ) {
     field(INP,  "$(P)$(R):MOD$(ID=0)-Status.BC CP " )
     field(DESC, "Module in good state" )
-    field(ZNAM, "failure" )
-    field(ONAM, "ok" )
-    field(ZSV,  "MAJOR" )
-    field(OSV,  "NO_ALARM" )
+    field(ZNAM, "ok" )
+    field(ONAM, "failure" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
 }
 
 record( bi, "$(P)$(R):MOD$(ID=0)-SupplyGood" ) {
     field(INP,  "$(P)$(R):MOD$(ID=0)-Status.BD CP " )
     field(DESC, "Power supply good" )
-    field(ZNAM, "Out of Range" )
-    field(ONAM, "ok" )
-    field(ZSV,  "MAJOR" )
-    field(OSV,  "NO_ALARM" )
+    field(ZNAM, "ok" )
+    field(ONAM, "Out of Range" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
 }
 
 record( bi, "$(P)$(R):MOD$(ID=0)-TemperatureGood" ) {
     field(INP,  "$(P)$(R):MOD$(ID=0)-Status.BE CP " )
     field(DESC, "Module temperature good" )
-    field(ZNAM, "above 55 degC" )
-    field(ONAM, "within range" )
-    field(ZSV,  "MAJOR" )
-    field(OSV,  "NO_ALARM" )
+    field(ZNAM, "within range" )
+    field(ONAM, "above 55 degC" )
+    field(ZSV,  "NO_ALARM" )
+    field(OSV,  "MAJOR" )
 }
 
 record( bi, "$(P)$(R):MOD$(ID=0)-KillEnable" ) {

--- a/drvAsynIseghalServiceApp/Db/system-items.template
+++ b/drvAsynIseghalServiceApp/Db/system-items.template
@@ -90,7 +90,7 @@ record( stringin, "$(P)$(R):SYS-LogPath-RB") {
     field(TSE,  "-2")
 }
 
-record(longout, "$(P)$(R):SYS-LogLevel") {
+record(mbbo, "$(P)$(R):SYS-LogLevel") {
     field(DTYP, "asynInt32")
     field(OUT,  "@asyn($(PORT))INT_LogLevel")
     field(ZRVL, "1")

--- a/drvAsynIseghalServiceApp/Db/system-items.template
+++ b/drvAsynIseghalServiceApp/Db/system-items.template
@@ -4,8 +4,8 @@
 
 record( longin, "$(P)$(R):SYS-Status") {
     field(DESC, "CAN system Status")
-    field(DTYP, "asynUInt32Digital")
-    field(INP,  "@asynMask($(PORT),0, 0xf)DIG_Status")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT))INT_Status")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
 }
@@ -90,9 +90,9 @@ record( stringin, "$(P)$(R):SYS-LogPath-RB") {
     field(TSE,  "-2")
 }
 
-record(mbbo, "$(P)$(R):SYS-LogLevel") {
-    field(DTYP, "asynUInt32Digital")
-    field(OUT,  "@asynMask($(PORT),0, 0xf)DIG_LogLevel")
+record(longout, "$(P)$(R):SYS-LogLevel") {
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT))INT_LogLevel")
     field(ZRVL, "1")
     field(ZRST, "Log Errors")
     field(ONVL, "2")
@@ -121,5 +121,5 @@ record(mbbo, "$(P)$(R):SYS-LogLevel") {
     field(TTST, "Log Scpi Write Request")
 
     info(asyn:READBACK, "1")
-    info(DESCRIPTION, "Set RF Control Ouput Sel, on I and Q")
+    info(DESCRIPTION, "Set Log Level at system level")
 }

--- a/drvAsynIseghalServiceApp/src/drvAsynIseghalService.cpp
+++ b/drvAsynIseghalServiceApp/src/drvAsynIseghalService.cpp
@@ -60,7 +60,7 @@ std::vector<std::string> validIsegHalItems
    "CrateNumber",
    "CrateList",
    "ModuleNumber",
-	 "ModuleList",
+   "ModuleList",
    "CycleCounter",
    "Read",
    "LogLevel",
@@ -98,7 +98,7 @@ std::vector<std::string> validIsegHalItems
    "DoClear",
    "FineAdjustment",
    "KillEnable" ,
-	 "ChannelNumber",
+   "ChannelNumber",
   // MICC option
    "HighVoltageOk",
 
@@ -175,66 +175,6 @@ std::vector<std::string> validIsegHalItems
    "UserConfigFlags",
 };
 
-/** Connect to iseg device
-  *
-  * This method finds or connect to a device.  It is called from the driver constructor.
-  * \param [in]  name        drvAsynIseghalService internal name of the interface handle
-  * \param [in]  interface   name of the hardware interface
-  * \return      true if interface is already connected or if successfully connected
-*/
-int drvAsynIseghalService::devConnect( std::string const& name, std::string const& interface ) {
-
-  if (devInitOk_) {
-    if( iseg_isConnError(name.c_str()) ) {
-    // We session was disconnected! attempt reconexion n times
-    // otherwise close the connexion and open a new one. we use autoconnect freq here.
-        asynPrint( pasynUserSelf, ASYN_TRACEIO_DRIVER,"%s: Attempting reconnexion... to %s\n", name.c_str(), interface.c_str() );
-
-        IsegResult status = iseg_reconnect(name.c_str(), interface.c_str() );
-        if ( ISEG_OK != status ) return false;
-        conMan_ = 0;
-        drvIsegHalPollerThread_->changeIntervall(2.0);
-    }
-  }
-  else {
-    asynPrint( pasynUserSelf, ASYN_TRACEIO_DRIVER,"%s: Open connection to %s\n", name.c_str(), interface.c_str() );
-    IsegResult status = iseg_connect( name.c_str(), interface.c_str(), NULL );
-    if ( ISEG_OK != status ) return false;
-    // new iseghal session to iseg device.
-    openedSessions.push_back( name );
-    devInitOk_ = true;
-  }
-
-  /* iseg HAL starts collecting data from hardware after connect.
-    * wait 5 secs to let all values 'initialize'
-  */
-  epicsThreadSleep( 5 );
-  return true;
-}
-
-
-/** Disconnect from iseg device session
-  * \param [in]  name   drvAsynIseghalService internal name of the interface handle
-*/
-int drvAsynIseghalService::devDisconnect( std::string const& name ) {
-
-    int status = iseg_disconnect( name.c_str() );
-    if ( status != ISEG_OK  ) return false;
-    openedSessions.clear();
-    return true;
-}
-
-
-/** Check if a device is connected
-  * name:   drvAsynIseghalService internal name of the interface handle
-*/
-int drvAsynIseghalService::devConnected( std::string const& name ) {
-  std::vector< std::string >::iterator it;
-  it = std::find( openedSessions.begin(), openedSessions.end(), name );
-  // cant access hal object unless connect was successfully called
-  if(!devInitOk_) return false;
-  return ( it != openedSessions.end() && !iseg_isConnError(name.c_str()));
-}
 
 /** Called by epicsAtExit to shutdown iseghal session */
 static void iseghalSessionShutdown( void* pDrv) {
@@ -265,7 +205,7 @@ drvAsynIseghalService::drvAsynIseghalService( const char *portName, const char *
     asynCommonMask | asynInt32Mask | asynUInt32DigitalMask | asynFloat64Mask | asynOctetMask | asynDrvUserMask,
     asynCommonMask | asynInt32Mask | asynUInt32DigitalMask | asynFloat64Mask | asynOctetMask,
     ASYN_CANBLOCK |ASYN_MULTIDEVICE, // asynFlags.
-    1, // Autoconnect
+    autoConnect, // Autoconnect
     0, // Default priority
     0 ), // Default stack size
     iseghalExiting_(false),
@@ -275,12 +215,12 @@ drvAsynIseghalService::drvAsynIseghalService( const char *portName, const char *
 {
     static const char *functionName = "drvAsynIseghalService";
 
-    session_  		= epicsStrDup( portName );
+    session_      = epicsStrDup( portName );
     interface_    = epicsStrDup( interface );
-    deviceModel_	= epicsStrDup( icsCtrtype );
-		itemReason_ 	= 0;
-    devInitOk_ 		= 0;
-    exitUser_ 		= pasynManager->createAsynUser(0, 0);
+    deviceModel_  = epicsStrDup( icsCtrtype );
+    itemReason_   = 0;
+    devInitOk_    = 0;
+    exitUser_     = pasynManager->createAsynUser(0, 0);
 
     asynStatus status;
 
@@ -291,31 +231,22 @@ drvAsynIseghalService::drvAsynIseghalService( const char *portName, const char *
       return;
     }
 
-		/* iseg HAL starts collecting data from hardware after connect.
-			* allow 5 secs timeout to let all values 'initialize'
-		*/
+    /* iseg HAL starts collecting data from hardware after connect.
+      * allow 5 secs timeout to let all values 'initialize'
+    */
     pasynManager->setAutoConnectTimeout(5.0);
 
-		hookMutexId = epicsMutexCreate();
+    hookMutexId = epicsMutexCreate();
     /* Register the shutdown function for epicsAtExit */
     epicsAtExit(iseghalSessionShutdown, (void*)this);
 
-		/* Register the start polling fucntion: we wait till ioc is in running state before starting */
+    /* Register the start polling fucntion: we wait till ioc is in running state before starting */
     initHookRegister(startPolling);
 
-		// instantiate the polling thread, but dont start yet.
+    // instantiate the polling thread, but dont start yet.
     drvIsegHalPollerThread_ = new drvIsegHalPollerThread(this);
     if(!drvIsegHalPollerThread_) return;
 
-}
-
-char *drvAsynIseghalService::getSessionName (){
-  return session_;
-}
-
-asynStandardInterfaces drvAsynIseghalService::getAsynStdIface()
-{
-  return asynStdInterfaces;
 }
 
 asynStatus drvAsynIseghalService::getIsegHalItem (asynUser *isegHalUser, IsegItem *item)
@@ -352,8 +283,8 @@ asynStatus drvAsynIseghalService::getIsegHalItem (asynUser *isegHalUser, IsegIte
   }
 
   IsegItemProperty itemProperty = iseg_getItemProperty( session_, propertyName );
-	//printf("\033[0;33m%s : %s : propertyName %s: Permission %s\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__, propertyName, itemProperty.access);
-  if(!(strcmp( itemProperty.access, "R" ) == 0 || strcmp( itemProperty.access, "RW" ) == 0) ) {
+  //printf("\033[0;33m%s : %s : propertyName %s: Permission %s\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__, propertyName, itemProperty.access);
+  if(!(epicsStrCaseCmp( itemProperty.access, "R" ) == 0 || epicsStrCaseCmp( itemProperty.access, "RW" ) == 0) ) {
 
     epicsSnprintf( isegHalUser->errorMessage, isegHalUser->errorMessageSize,
       "\033[31;1m%s:%s Wrong item '%s' permission: Access right: '%s'\033[0m\n",
@@ -368,7 +299,7 @@ asynStatus drvAsynIseghalService::getIsegHalItem (asynUser *isegHalUser, IsegIte
 
   if( strcmp( item->quality, ISEG_ITEM_QUALITY_OK ) != 0 ) {
     epicsSnprintf( isegHalUser->errorMessage,isegHalUser->errorMessageSize,"\033[31;1m%s:%s Error reading from device (Q: %s): %s\033[0m",
-									session_, functionName, item->quality, strerror( errno ) );
+                  session_, functionName, item->quality, strerror( errno ) );
 
     isegHalUser->alarmStatus = 1;
     isegHalUser->alarmSeverity = 3;
@@ -431,7 +362,7 @@ asynStatus drvAsynIseghalService::writeFloat64( asynUser *pasynUser, epicsFloat6
 
   IsegItemProperty itemProperty = iseg_getItemProperty( session_, propertyName );
 
-  if(strcmp( itemProperty.access, "RW" ) != 0) {
+  if(epicsStrCaseCmp( itemProperty.access, "RW" ) != 0) {
 
     epicsSnprintf( pasynUser->errorMessage, pasynUser->errorMessageSize,
       "\033[31;1m%s:%s Wrong permission on iseghal item %s access right: '%s'\033[0m\n",
@@ -464,7 +395,7 @@ asynStatus drvAsynIseghalService::writeFloat64( asynUser *pasynUser, epicsFloat6
 
   // update value of parameter
   status = (asynStatus) setDoubleParam(function, value);
-	status = (asynStatus) callParamCallbacks();
+  status = (asynStatus) callParamCallbacks();
   if( status )
     epicsSnprintf( pasynUser->errorMessage, pasynUser->errorMessageSize,
                    "%s:%s: status=%d, function=%d, value=%f",
@@ -499,8 +430,8 @@ asynStatus drvAsynIseghalService::readFloat64( asynUser *pasynUser, epicsFloat64
   asynStatus status = asynSuccess;
 
   printf("\033[0;33m%s : (%s) : Reason: '%d'\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__, function);
-	status = getIsegHalItem (pasynUser, &item);
-	if(status != asynSuccess) return asynError;
+  status = getIsegHalItem (pasynUser, &item);
+  if(status != asynSuccess) return asynError;
 
   // set new paramter value and update record val field
   dVal = (epicsFloat64)strtod (item.value, NULL);
@@ -546,8 +477,8 @@ asynStatus drvAsynIseghalService::readUInt32Digital( asynUser *pasynUser, epicsU
   IsegItem item = EmptyIsegItem;
   epicsUInt32 iVal = 0;
 
-	status = getIsegHalItem (pasynUser, &item);
-	if(status != asynSuccess) return asynError;
+  status = getIsegHalItem (pasynUser, &item);
+  if(status != asynSuccess) return asynError;
 
   iVal = (epicsUInt32)atoi(item.value);
   *value = iVal;
@@ -625,7 +556,7 @@ asynStatus drvAsynIseghalService::writeUInt32Digital( asynUser *pasynUser, epics
 
   IsegItemProperty itemProperty = iseg_getItemProperty( session_, propertyName );
 
-  if(strcmp( itemProperty.access, "RW" ) != 0) {
+  if(epicsStrCaseCmp( itemProperty.access, "RW" ) != 0) {
 
     epicsSnprintf( pasynUser->errorMessage, pasynUser->errorMessageSize,
       "\033[31;1m%s:%s Wrong permission on iseghal item %s access right: '%s'\033[0m\n",
@@ -683,8 +614,8 @@ asynStatus drvAsynIseghalService::readInt32(asynUser *pasynUser, epicsInt32 *val
   IsegItem item = EmptyIsegItem;
   epicsInt32 iVal = 0;
 
-	status = getIsegHalItem (pasynUser, &item);
-	if(status != asynSuccess) return asynError;
+  status = getIsegHalItem (pasynUser, &item);
+  if(status != asynSuccess) return asynError;
 
   // set new paramter value and update record val field
   iVal = (epicsInt32)atoi(item.value);
@@ -739,7 +670,7 @@ asynStatus drvAsynIseghalService::writeInt32(asynUser *pasynUser, epicsInt32 val
 
   IsegItemProperty itemProperty = iseg_getItemProperty( session_, propertyName );
 
-  if(strcmp( itemProperty.access, "RW" ) != 0) {
+  if(epicsStrCaseCmp( itemProperty.access, "RW" ) != 0) {
 
     epicsSnprintf( pasynUser->errorMessage, pasynUser->errorMessageSize,
       "\033[31;1m%s:%s Wrong permission on iseghal item %s access right: '%s'\033[0m\n",
@@ -797,8 +728,8 @@ asynStatus drvAsynIseghalService::readOctet(asynUser *pasynUser, char *value, si
   IsegItem item = EmptyIsegItem;
   asynStatus status = asynSuccess;
 
-	status = getIsegHalItem (pasynUser, &item);
-	if(status != asynSuccess) return asynError;
+  status = getIsegHalItem (pasynUser, &item);
+  if(status != asynSuccess) return asynError;
 
   strncpy(value, item.value, maxChars);
   *nActual = strlen(item.value);
@@ -850,7 +781,7 @@ asynStatus drvAsynIseghalService::writeOctet(asynUser *pasynUser, const char *va
 
   IsegItemProperty itemProperty = iseg_getItemProperty( session_, propertyName );
 
-  if(strcmp( itemProperty.access, "RW" ) != 0) {
+  if(epicsStrCaseCmp( itemProperty.access, "RW" ) != 0) {
 
     epicsSnprintf( pasynUser->errorMessage, pasynUser->errorMessageSize,
       "\033[31;1m%s:%s Wrong permission on iseghal item %s access right: '%s'\033[0m\n",
@@ -918,14 +849,14 @@ asynStatus drvAsynIseghalService::drvUserCreate(asynUser *pasynUser, const char 
   * The fully qualified name (FQN) for gettting/setting an item value is ADDR.item, this is used to create the corresponding iseghalitem parameter.
   */
   unsigned int len = 0;
-	unsigned int prevLen = 0;
+  unsigned int prevLen = 0;
   const char *p;
   const char *pnext;
 
-	char halItemType[4];
+  char halItemType[4];
   char ctrlhalItemFQNAddr[4];
   char halItemProperty[FQN_LEN];
-	char tmp[FQN_LEN];
+  char tmp[FQN_LEN];
 
   if (strlen(drvInfo) > 4 ) {
 
@@ -954,8 +885,8 @@ asynStatus drvAsynIseghalService::drvUserCreate(asynUser *pasynUser, const char 
     for(len=0; *p && isalpha(*p); len++, p++){}
     // 3: we expect 2  additional character for control param address
     strncpy(tmp, pnext, len);
-		prevLen = len;
-		*(tmp+len)=0x0; // terminate string
+    prevLen = len;
+    *(tmp+len)=0x0; // terminate string
 
     if (!this->hasIsegHalItem(tmp)) {
       asynPrint(pasynUser, ASYN_TRACE_ERROR,
@@ -966,19 +897,19 @@ asynStatus drvAsynIseghalService::drvUserCreate(asynUser *pasynUser, const char 
       pasynUser->alarmSeverity = 3;   // INVALID
       return asynError;
     }
-		if(strcmp(tmp, "Control") == 0) {
+    if(strcmp(tmp, "Control") == 0) {
       p++; // skip this ':'
       pnext = p;
       for(len=0; *p && isdigit(*p); len++, p++){}
       strncpy(ctrlhalItemFQNAddr, pnext, len);
-			prevLen+=len;
+      prevLen+=len;
       epicsSnprintf(halItemProperty, prevLen, "%s:%s", tmp, ctrlhalItemFQNAddr);
       *(tmp+prevLen) = 0x0;
 
     }
     strcpy(halItemProperty, tmp);
     *(halItemProperty+prevLen) = 0x0;
-		//printf("\033[0;33m%s : (%s) : drvInfo-good: '%s':'%s'\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__, halItemType, halItemProperty);
+    //printf("\033[0;33m%s : (%s) : drvInfo-good: '%s':'%s'\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__, halItemType, halItemProperty);
 
     char halItemFQN[FQN_LEN];
     //next is addr, no addr for system items
@@ -1004,7 +935,7 @@ asynStatus drvAsynIseghalService::drvUserCreate(asynUser *pasynUser, const char 
       }
 
     }
-		else {
+    else {
       pnext++;
       p = skipWhite(pnext,0);
 
@@ -1018,34 +949,33 @@ asynStatus drvAsynIseghalService::drvUserCreate(asynUser *pasynUser, const char 
       char halItemFQNAddr[6];
       strncpy(halItemFQNAddr, pnext, len);
       *(halItemFQNAddr+len)=0;
-			prevLen+=len;
+      prevLen+=len;
       // Create fully qualified object for system items
       epicsSnprintf(halItemFQN, FQN_LEN, "%s.%s", halItemFQNAddr, halItemProperty);
     }
 
-		//printf("\033[0;33m%s : (%s) : drvInfo-good: '%s':'%s':'%s'\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__, halItemType, halItemProperty, halItemFQN);
     int index;
     if (findParam(halItemFQN, &index) == asynParamNotFound) {
       //Create parameter of the correct type
-
-      if( strcmp(halItemType, "INT") == 0) {
+      if( epicsStrCaseCmp(halItemType, "INT") == 0) {
           createParam(halItemFQN, asynParamInt32, &itemReason_);
           setIntegerParam (itemReason_,       0);
 
-      } else if (strcmp(halItemType, "DBL") == 0) {
+      } else if (epicsStrCaseCmp(halItemType, "DBL") == 0) {
           createParam(halItemFQN, asynParamFloat64, &itemReason_);
           setDoubleParam (itemReason_,       0.0);
 
-      } else if (strcmp(halItemType, "STR") == 0) {
+      } else if (epicsStrCaseCmp(halItemType, "STR") == 0) {
           createParam(halItemFQN, asynParamOctet, &itemReason_);
           setStringParam(itemReason_,         "0.0");
 
-      } else if (strcmp(halItemType, "DIG") == 0) {
+      } else if (epicsStrCaseCmp(halItemType, "DIG") == 0) {
           createParam(halItemFQN, asynParamUInt32Digital, &itemReason_);
-					setUIntDigitalParam(itemReason_, 0, 0xf );
+          setUIntDigitalParam(itemReason_, 0, 0xf );
+
       } else {
-          asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
-                      "%s:%s: Expected Type is INT|DBL|STR|DIG. Got '%s'\n", driverName, functionName, halItemType);
+          asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,"%s:%s: Expected Type is INT|DBL|STR|DIG. Got '%s'\n",
+                    driverName, functionName, halItemType);
           return asynError;
       }
 
@@ -1057,7 +987,7 @@ asynStatus drvAsynIseghalService::drvUserCreate(asynUser *pasynUser, const char 
     } else {
       pasynUser->reason = index;
     }
-	}
+  }
 
   return asynSuccess;
 }
@@ -1081,7 +1011,7 @@ asynStatus drvAsynIseghalService::connect(asynUser *pasynUser) {
 /* check if devices is responsive.
   * iCSModel: iseg iCS based HV system controller model
   * cc24: for crate systems
-	* icsmini: system exposes the first crate controller module model i.e MICC.
+  * icsmini: system exposes the first crate controller module model i.e MICC.
 */
 
   char iCSModel[FQN_LEN];
@@ -1110,6 +1040,78 @@ asynStatus drvAsynIseghalService::connect(asynUser *pasynUser) {
 
 }
 
+/** Connect to iseg device
+  *
+  * This method finds or connect to a device.  It is called from the driver constructor.
+  * \param [in]  name        drvAsynIseghalService internal name of the interface handle
+  * \param [in]  interface   name of the hardware interface
+  * \return      true if interface is already connected or if successfully connected
+*/
+int drvAsynIseghalService::devConnect( std::string const& name, std::string const& interface ) {
+
+  if (devInitOk_) {
+    if( iseg_isConnError(name.c_str()) ) {
+    // We session was disconnected! attempt reconexion n times
+    // otherwise close the connexion and open a new one. we use autoconnect freq here.
+        asynPrint( pasynUserSelf, ASYN_TRACEIO_DRIVER,"%s: Attempting reconnexion to %s\n", name.c_str(), interface.c_str() );
+
+        IsegResult status = iseg_reconnect(name.c_str(), interface.c_str() );
+        if ( ISEG_OK != status ) return false;
+        conMan_ = 0;
+        drvIsegHalPollerThread_->changeIntervall(2.0);
+    }
+  }
+  else {
+    asynPrint( pasynUserSelf, ASYN_TRACEIO_DRIVER,"%s: Opening connection to %s\n", name.c_str(), interface.c_str() );
+    IsegResult status = iseg_connect( name.c_str(), interface.c_str(), NULL );
+    if ( ISEG_OK != status ) return false;
+    // new iseghal session to iseg device.
+    openedSessions.push_back( name );
+    devInitOk_ = true;
+  }
+
+  /* iseg HAL starts collecting data from hardware after connect.
+    * wait 5 secs to let all values 'initialize'
+  */
+  epicsThreadSleep( 5 );
+  return true;
+}
+
+
+/** Disconnect from iseg device session
+  * \param [in]  name   drvAsynIseghalService internal name of the interface handle
+*/
+int drvAsynIseghalService::devDisconnect( std::string const& name ) {
+
+    int status = iseg_disconnect( name.c_str() );
+    if ( status != ISEG_OK  ) return false;
+    openedSessions.clear();
+    return true;
+}
+
+
+/** Check if a device is connected
+  * name:   drvAsynIseghalService internal name of the interface handle
+*/
+int drvAsynIseghalService::devConnected( std::string const& name ) {
+  std::vector< std::string >::iterator it;
+  it = std::find( openedSessions.begin(), openedSessions.end(), name );
+  // cant access hal object unless connect was successfully called
+  if(!devInitOk_) return false;
+  return ( it != openedSessions.end() && !iseg_isConnError(name.c_str()));
+}
+
+char *drvAsynIseghalService::getSessionName (){
+  return session_;
+}
+
+asynStandardInterfaces drvAsynIseghalService::getAsynStdIface()
+{
+  return asynStdInterfaces;
+}
+
+
+
 /**
 * @brief       Disconnect driver from device
 * @param [in]  pasynUser  pasynUser structure that encodes the reason and address.
@@ -1122,7 +1124,7 @@ asynStatus drvAsynIseghalService::disconnect(asynUser *pasynUser) {
 
   asynPrint( pasynUser, ASYN_TRACEIO_DRIVER,
              "%s: disconnect %s\n", session_, interface_ );
-  // we only disconnect from the device if exiting or if multiple reconnexion
+  // we only disconnect from the device if exiting
   // attempts to the current device session failed.
   if(iseghalExiting_) {
     if( !devDisconnect( session_ )) {
@@ -1131,10 +1133,10 @@ asynStatus drvAsynIseghalService::disconnect(asynUser *pasynUser) {
       return asynError;
     }
   }
+
   // if this call is not a shutdown exit, thus we lost connection to device
   // iseghal will internally issues a reconnexion to the server. we need to listen to that
-  // inside our connect method called by autoconnect. for that we make the call below:
-
+  // inside our connect method called by autoconnect.
   pasynManager->exceptionDisconnect(pasynUser);
   conMan_ = true;
   return asynSuccess;
@@ -1155,6 +1157,7 @@ extern "C" {
     new drvAsynIseghalService( portName, interface, icsCtrtype, autoConnect );
     return( asynSuccess );
   }
+
   static const iocshArg initIseghalServiceArg0 = { "portName",    iocshArgString };
   static const iocshArg initIseghalServiceArg1 = { "interface",   iocshArgString };
   static const iocshArg initIseghalServiceArg2 = { "icsCtrtype",  iocshArgString };
@@ -1166,11 +1169,57 @@ extern "C" {
     drvAsynIseghalServiceConfig( args[0].sval, args[1].sval, args[2].sval, args[3].ival );
   }
 
+  // iocsh function to set options for drv IsegHal Poller Thread
+  static const iocshArg setOptArg0 = { "port", iocshArgString };
+  static const iocshArg setOptArg1 = { "key", iocshArgString };
+  static const iocshArg setOptArg2 = { "value",  iocshArgString };
+  static const iocshArg * const setOptArgs[] = { &setOptArg0, &setOptArg1, &setOptArg2 };
+  static const iocshFuncDef setOptFuncDef = { "drvIsegHalPollerThreadSetOpt", 3, setOptArgs };
+
+	/*** iocsh callable function to set options for the polling thread
+	 * This function can be called from the iocsh via "drvIsegHalPollerThreadSetOpt( PORT, KEY, VALUE )"
+	 * \param[in] PORT is the drvAsynIseghalService internal name of the interface connected to the isegHalServer,
+	 * \param[in] KEY is the name of the option and VALUE the new value for the option.
+	 * KEYs are:
+	 * Intervall - set the wait time after going through the list of records inside polling thread
+	 * debug     - Enable debug output of polling thread
+	*/
+	static void setOptCallFunc( const iocshArgBuf *args )
+	{
+		// Set new intervall for polling thread
+		if( strcmp( args[1].sval, "Intervall" ) == 0 ) {
+			double pollingFreq = 0.;
+			int n = sscanf( args[2].sval, "%lf", &pollingFreq );
+			if( 1 != n ) {
+					fprintf( stderr, "\033[31;1mInvalid value for key '%s': %s\033[0m\n", args[1].sval, args[2].sval );
+					return;
+			}
+				drvIsegHalPollerThread_->changeIntervall( pollingFreq );
+		}
+
+		// Set new debug level
+		if( strcmp( args[1].sval, "debug" ) == 0 ) {
+			unsigned dbgLevel = 0;
+			int n = sscanf( args[2].sval, "%u", &dbgLevel );
+			if( 1 != n ) {
+				fprintf( stderr, "\033[31;1mInvalid value for key '%s': %s\033[0m\n", args[1].sval, args[2].sval );
+				return;
+			}
+			drvIsegHalPollerThread_->setDbgLvl( dbgLevel );
+		}
+	}
+
   /*
   * @brief   Register functions to EPICS
   */
   void drvAsynIseghalServiceRegister( void ) {
+		static bool firstTime = true;
+		if ( firstTime ) {
       iocshRegister( &initIseghalServiceFuncDef, initIseghalServiceCallFunc );
+      iocshRegister( &setOptFuncDef, setOptCallFunc );
+			firstTime = false;
+		}
+
   }
   epicsExportRegistrar( drvAsynIseghalServiceRegister );
 }

--- a/drvAsynIseghalServiceApp/src/drvAsynIseghalService.cpp
+++ b/drvAsynIseghalServiceApp/src/drvAsynIseghalService.cpp
@@ -903,14 +903,15 @@ asynStatus drvAsynIseghalService::drvUserCreate(asynUser *pasynUser, const char 
       pnext = p;
       for(len=0; *p && isdigit(*p); len++, p++){}
       strncpy(ctrlhalItemFQNAddr, pnext, len);
-      prevLen+=len;
+      prevLen+=(len+2);
       epicsSnprintf(halItemProperty, prevLen, "%s:%s", tmp, ctrlhalItemFQNAddr);
-      *(tmp+prevLen) = 0x0;
-
-    }
-    strcpy(halItemProperty, tmp);
-    *(halItemProperty+prevLen) = 0x0;
-    //printf("\033[0;33m%s : (%s) : drvInfo-good: '%s':'%s'\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__, halItemType, halItemProperty);
+      //printf("\033[0;33m%s : (%s) : address: '%s':'%s' %d\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__, ctrlhalItemFQNAddr, halItemProperty, prevLen);
+      *(halItemProperty+(prevLen)) = 0x0;
+    } else {
+			strcpy(halItemProperty, tmp);
+			*(halItemProperty+prevLen) = 0x0;
+			//printf("\033[0;33m%s : (%s) : drvInfo-good: '%s':'%s'\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__, halItemType, halItemProperty);
+		}
 
     char halItemFQN[FQN_LEN];
     //next is addr, no addr for system items

--- a/drvAsynIseghalServiceApp/src/drvAsynIseghalService.cpp
+++ b/drvAsynIseghalServiceApp/src/drvAsynIseghalService.cpp
@@ -279,6 +279,8 @@ asynStatus drvAsynIseghalService::getIsegHalItem (asynUser *isegHalUser, IsegIte
       this->disconnect(isegHalUser);
       drvIsegHalPollerThread_->changeIntervall(10.0);
     }
+    isegHalUser->alarmStatus		= 1;
+    isegHalUser->alarmSeverity	= 3;
     return asynError;
   }
 

--- a/drvAsynIseghalServiceApp/src/drvIsegHalPollerThread.cpp
+++ b/drvAsynIseghalServiceApp/src/drvIsegHalPollerThread.cpp
@@ -43,7 +43,7 @@ static void drvIsegHalPollerThreadShutdown( void* pdrv)
   asynStatus status;
   drvIsegHalPollerThread *pPvt = (drvIsegHalPollerThread *) pdrv;
   pPvt->_drvIsegHalPollerThreadExiting = true;
-  printf("\033[0;33m%s : %s : Shutting down...\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__ );
+  printf("\033[0;36m%s:%s Shutting down...\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__ );
   delete pPvt;
 }
 
@@ -58,7 +58,7 @@ static void  drvIsegHalPollerThreadCallackBack(asynUser *pasynUser)
   IsegItem item = EmptyIsegItem;
 	asynStatus status = asynSuccess;
 
-  printf("\033[0;33m%s : (%s) : reason: '%d'\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__, pasynUser->reason );
+  printf("\033[0;36m%s:(%s) Reason '%d'\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__, pasynUser->reason );
 
 	if(drvAsynIseghalService_)
 		drvAsynIseghalService_->lock();
@@ -75,7 +75,7 @@ static void  drvIsegHalPollerThreadCallackBack(asynUser *pasynUser)
 		if (mask != 0 ) uInt32Value &= mask;
 
 		if(status != asynSuccess) uInt32Value = NAN;
-		printf("\033[0;33m%s : %s : %d: item value: %s: value: %d\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__, __LINE__, item.value,uInt32Value );
+		printf("\033[0;36m%s : (%s) item value %s converted %d\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__, item.value, uInt32Value );
     pUInt32D->callback(pUInt32D->userPvt, pasynUser, uInt32Value);
   }
 
@@ -85,9 +85,8 @@ static void  drvIsegHalPollerThreadCallackBack(asynUser *pasynUser)
 
     epicsFloat64 float64Value;
 		float64Value = (epicsFloat64)strtod (item.value, NULL);
-
 		if(status != asynSuccess) float64Value = NAN;
-				printf("\033[0;33m%s : %s : %d: item value: %s: value: %f\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__, __LINE__, item.value,float64Value);
+				printf("\033[0;36m%s:(%s) item value %s converted %lf\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__, item.value,float64Value);
     pFloat64->callback(pFloat64->userPvt, pasynUser, float64Value);
   }
   else if (ifaceType == INT32TYPE)
@@ -97,7 +96,7 @@ static void  drvIsegHalPollerThreadCallackBack(asynUser *pasynUser)
 		int32Value = (epicsInt32)atoi(item.value);
 
 		if(status != asynSuccess) int32Value = NAN;
-				printf("\033[0;33m%s : %s : %d: item value: %s: value: %d\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__, __LINE__, item.value,int32Value );
+				printf("\033[0;36m%s:(%s) item value %s converted %d\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__, item.value,int32Value );
     pInt32->callback(pInt32->userPvt, pasynUser, int32Value);
   } else {
       asynPrint(pasynUser, ASYN_TRACE_ERROR,
@@ -119,21 +118,21 @@ drvIsegHalPollerThread::drvIsegHalPollerThread(drvAsynIseghalService *portD)
   drvAsynIseghalService_ = portD;
   _pasynIntrUser.clear();
   epicsAtExit(drvIsegHalPollerThreadShutdown, (void*)this);
-  printf("\033[0;33m%s : (%s) : Initialization completed \n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__ );
+  printf("\033[0;36m%s:(%s) : Initialization completed \n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__ );
 }
 
-//------------------------------------------------------------------------------
-//! @brief       D'tor of drvIsegHalPollerThreaddbl
-//------------------------------------------------------------------------------
+/*
+	* @brief       D'tor of drvIsegHalPollerThreaddbl
+*/
 drvIsegHalPollerThread::~drvIsegHalPollerThread()
 {
 
-  // Clean space used for intr users
+  // Clean up space used for intr users
   intrUserItr _intrUserItr = _pasynIntrUser.begin();
   for( ; _intrUserItr != _pasynIntrUser.end(); ++_intrUserItr ) {
     pasynManager->freeAsynUser((asynUser *)(*_intrUserItr));
   }
-  // Clean intr data allocated storage
+  // Clean up intr data allocated storage
   intrUserDataItr _intrUserDataItr = _intrUser_data_gbg.begin();
   for( ; _intrUserDataItr != _intrUser_data_gbg.end(); ++_intrUserDataItr ) {
     free((intrUser_data_t *)(*_intrUserDataItr));
@@ -143,7 +142,7 @@ drvIsegHalPollerThread::~drvIsegHalPollerThread()
  _intrUser_data_gbg.clear();
  drvAsynIseghalService_ = NULL;
 
- printf("\033[0;33m%s : %s : Cleaning up...\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__ );
+ printf("\033[0;36m%s:%s Poller thread cleaning up completed!\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__ );
 
 }
 
@@ -228,7 +227,7 @@ void drvIsegHalPollerThread::run()
   while(true) {
 
     if( _drvIsegHalPollerThreadExiting ) {
-      printf("\033[0;33m%s : %s : Exiting...\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__ );
+      printf("\033[0;36m%s:%s Exiting Poller thread...\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__ );
       break;
     }
 

--- a/drvAsynIseghalServiceApp/src/drvIsegHalPollerThread.cpp
+++ b/drvAsynIseghalServiceApp/src/drvIsegHalPollerThread.cpp
@@ -65,16 +65,21 @@ static void  drvIsegHalPollerThreadCallackBack(asynUser *pasynUser)
 		status = drvAsynIseghalService_->getIsegHalItem(pasynUser, &item);
 		drvAsynIseghalService_->unlock();
 
-  if(ifaceType == UINT32DIGITALTYPE) {
-    asynUInt32DigitalInterrupt *pUInt32D = (asynUInt32DigitalInterrupt*)intrUser->intrHandle;
+	if(status == asynSuccess) {
+		pasynUser->alarmStatus 		= 0;
+		pasynUser->alarmSeverity	= 0;
+	}
 
+
+  if(ifaceType == UINT32DIGITALTYPE) {
+
+    asynUInt32DigitalInterrupt *pUInt32D = (asynUInt32DigitalInterrupt*)intrUser->intrHandle;
     epicsUInt32 uInt32Value;
 		uInt32Value =  (epicsUInt32)atoi(item.value) ;
 		mask = pUInt32D->mask;
-
 		if (mask != 0 ) uInt32Value &= mask;
-
 		if(status != asynSuccess) uInt32Value = NAN;
+
 		printf("\033[0;36m%s : (%s) item value %s converted %d\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__, item.value, uInt32Value );
     pUInt32D->callback(pUInt32D->userPvt, pasynUser, uInt32Value);
   }
@@ -82,11 +87,11 @@ static void  drvIsegHalPollerThreadCallackBack(asynUser *pasynUser)
   else if (ifaceType == FLOAT64TYPE)
   {
     asynFloat64Interrupt *pFloat64 = (asynFloat64Interrupt*)intrUser->intrHandle;
-
     epicsFloat64 float64Value;
 		float64Value = (epicsFloat64)strtod (item.value, NULL);
 		if(status != asynSuccess) float64Value = NAN;
-				printf("\033[0;36m%s:(%s) item value %s converted %lf\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__, item.value,float64Value);
+
+		printf("\033[0;36m%s:(%s) item value %s converted %lf\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__, item.value,float64Value);
     pFloat64->callback(pFloat64->userPvt, pasynUser, float64Value);
   }
   else if (ifaceType == INT32TYPE)
@@ -94,9 +99,9 @@ static void  drvIsegHalPollerThreadCallackBack(asynUser *pasynUser)
     asynInt32Interrupt *pInt32 = (asynInt32Interrupt*)intrUser->intrHandle;
     epicsInt32 int32Value;
 		int32Value = (epicsInt32)atoi(item.value);
-
 		if(status != asynSuccess) int32Value = NAN;
-				printf("\033[0;36m%s:(%s) item value %s converted %d\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__, item.value,int32Value );
+
+		printf("\033[0;36m%s:(%s) item value %s converted %d\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__, item.value,int32Value );
     pInt32->callback(pInt32->userPvt, pasynUser, int32Value);
   } else {
       asynPrint(pasynUser, ASYN_TRACE_ERROR,


### PR DESCRIPTION
- Fixing missing alarms status update on records when connexion loss and recover
- Fixed bug in 'drvUserCreate' method not correctly parsing 'Control'  properties address
- Fixing record type for LogLevel records, adding status decoding for crate and CAN Line status
- Using separate logging colour for poller thread debug messages. cleaning up poller thread source.
- Removing startup script from git consideration