### PR TITLE
Investigating Hanging poller thread, and no reconnection after device reconnection

### DIFF
--- a/drvAsynIsegHalServiceApp/src/drvAsynIsegHalService.h
+++ b/drvAsynIsegHalServiceApp/src/drvAsynIsegHalService.h
@@ -85,7 +85,7 @@ class drvAsynIsegHalService : public asynPortDriver {
     char  *deviceModel_;
     int   itemReason_;
 		bool  devInitOk_;
-		bool  conMan_;
+		bool  reconStatus_;
 		int   reconAttempt_;
     std::vector< std::string > openedSessions;
     std::map<epicsUInt32, std::string> isegHalItemsLookup;

--- a/drvAsynIsegHalServiceApp/src/drvIsegHalPollerThread.cpp
+++ b/drvAsynIsegHalServiceApp/src/drvIsegHalPollerThread.cpp
@@ -43,9 +43,9 @@ drvAsynIsegHalService *drvAsynIsegHalService_= NULL;
 static void drvIsegHalPollerThreadShutdown( void* pdrv)
 {
   drvIsegHalPollerThread *pPvt = (drvIsegHalPollerThread *) pdrv;
-	pPvt->pLock();
+/* 	pPvt->pLock(); */
   pPvt->_drvIsegHalPollerThreadExiting = true;
-	pPvt->pUnlock();
+/* 	pPvt->pUnlock(); */
   printf("\033[0;36m%s:%s Shutting down...\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__ );
   delete pPvt;
 }
@@ -163,6 +163,7 @@ asynStatus drvIsegHalPollerThread::pLock() {
     if (status) return asynError;
     else return asynSuccess;
 }
+
 asynStatus drvIsegHalPollerThread::pUnlock() {
 	epicsMutexUnlock(_pollMutexId);
 	return asynSuccess;
@@ -296,10 +297,10 @@ void drvIsegHalPollerThread::run()
       printf("\033[0;36m%s:%s Exiting poller thread...\n\033[0m", epicsThreadGetNameSelf(), __FUNCTION__ );
       break;
     }
-		pLock();
+/* 		pLock(); */
     if( _pause > 0. ) this->thread.sleep( _pause );
     if( !_run ) continue;
-		pUnlock();
+/* 		pUnlock(); */
 
     intrUserItr _intrUserItr = _pasynIntrUser.begin();
 		int _yesNo = 0;

--- a/patch/iseghal_service_lib_patch.p0.patch
+++ b/patch/iseghal_service_lib_patch.p0.patch
@@ -1,5 +1,5 @@
 diff --git isegHalRemoteClient/iseghalremote.cpp isegHalRemoteClient/iseghalremote.cpp
-index 8c68520..e03d1a1 100644
+index 8c68520..ce1686c 100644
 --- isegHalRemoteClient/iseghalremote.cpp
 +++ isegHalRemoteClient/iseghalremote.cpp
 @@ -30,6 +30,8 @@
@@ -121,6 +121,14 @@ index 8c68520..e03d1a1 100644
  bool IsegHalRemote::connectToHostEncrypted(const QString &host, quint16 port)
  {
  	m_socket->connectToHostEncrypted(host, port);
+@@ -146,6 +246,7 @@ IsegResult IsegHalRemote::isegConnect(const QString &session, const QString &int
+ 
+ IsegResult IsegHalRemote::isegDisconnect()
+ {
++	if( conError ) return ISEG_ERROR;
+ 	const QByteArray data = writeRead(ISEG_REMOTE_DISCONNECT);
+ 
+ 	m_socket->disconnectFromHost();
 diff --git isegHalRemoteClient/iseghalremote.h isegHalRemoteClient/iseghalremote.h
 index 60f6180..03202ea 100644
 --- isegHalRemoteClient/iseghalremote.h
@@ -160,7 +168,7 @@ index 60f6180..03202ea 100644
  
  #endif // ISEGHALREMOTE_H
 diff --git isegHalRemoteClient/isegremoteapi.cpp isegHalRemoteClient/isegremoteapi.cpp
-index 64f6458..7bb5de4 100644
+index 64f6458..0b00a88 100644
 --- isegHalRemoteClient/isegremoteapi.cpp
 +++ isegHalRemoteClient/isegremoteapi.cpp
 @@ -30,6 +30,7 @@
@@ -182,7 +190,7 @@ index 64f6458..7bb5de4 100644
  		return ISEG_WRONG_SESSION_NAME;
  
  	IsegHalRemote *hal = new IsegHalRemote();
-+  qInfo() <<"HAL socket instance created " << reinterpret_cast<void *>(hal) ;
++  qInfo() <<"HAL socket instance created " << (hal) ;
  
  	if (m_halTimeout.contains(name))
  		hal->setTimeout(m_halTimeout[name]);


### PR DESCRIPTION
- Fixed: Hanging poller thread, and no reconnection after device reconnection
- No poller thread instance if initial device connect fails.
- Remove locks and unlocks in driver methods